### PR TITLE
fix: ACTIVE 닉네임만 중복 검사 실행

### DIFF
--- a/src/main/java/com/ikdaman/domain/member/model/MemberReq.java
+++ b/src/main/java/com/ikdaman/domain/member/model/MemberReq.java
@@ -1,6 +1,7 @@
 package com.ikdaman.domain.member.model;
 
 import com.ikdaman.domain.member.entity.Member;
+import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDate;
 
@@ -20,9 +22,11 @@ import java.time.LocalDate;
 public class MemberReq {
 
     @NotBlank
-    @Size(min=1, max=20)
+    @Size(min=2, max=15, message = "닉네임은 최소 2자, 최대 15자만 가능합니다.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣\\\\s]+$", message = "닉네임은 한글, 영어, 숫자, 공백만을 포함합니다.")
     private String nickname;
     private Member.Gender gender;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate birthdate;
 
     @Builder

--- a/src/main/java/com/ikdaman/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/ikdaman/domain/member/repository/MemberRepository.java
@@ -12,6 +12,6 @@ import java.util.UUID;
 public interface MemberRepository extends JpaRepository<Member, UUID> {
     Optional<Member> findByNickname(String nickname);
     Optional<Member> findBySocialTypeAndProviderId(Member.SocialType socialType, String providerId);
-    Boolean existsByNickname(String nickname);
+    Boolean existsByNicknameAndStatus(String nickname, Member.Status status);
     Optional<Member> findByMemberIdAndStatus(UUID memberId, Member.Status status);
 }

--- a/src/main/java/com/ikdaman/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ikdaman/domain/member/service/MemberServiceImpl.java
@@ -45,7 +45,7 @@ public class MemberServiceImpl implements MemberService {
     @Override
     @Transactional(readOnly = true)
     public Boolean isAvailableNickname(String nickname) {
-        return !memberRepository.existsByNickname(nickname);
+        return !memberRepository.existsByNicknameAndStatus(nickname, Member.Status.ACTIVE);
     }
 
     @Override


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : memberReq에 대한 validation 추가
- [x] 버그 수정 : ACTIVE 닉네임만 중복 검사 실행하도록 수정
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 