### PR TITLE
feat: 내 정보 수정 시 null과 blank를 구분할 수 있도록 수정

### DIFF
--- a/src/main/java/com/ikdaman/domain/member/deserializer/BirthDateDeserializer.java
+++ b/src/main/java/com/ikdaman/domain/member/deserializer/BirthDateDeserializer.java
@@ -1,0 +1,25 @@
+package com.ikdaman.domain.member.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.time.LocalDate;
+
+public class BirthDateDeserializer extends JsonDeserializer<LocalDate> {
+    @Override
+    public LocalDate deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException {
+        String value = p.getValueAsString();
+        if (value == null) {
+            // 실제 null인 경우
+            return null;
+        }
+        if (value.trim().isEmpty()) {
+            // 빈 문자열인 경우
+            return LocalDate.MIN;
+        }
+        return LocalDate.parse(value);
+    }
+}

--- a/src/main/java/com/ikdaman/domain/member/deserializer/GenderDeserializer.java
+++ b/src/main/java/com/ikdaman/domain/member/deserializer/GenderDeserializer.java
@@ -1,0 +1,25 @@
+package com.ikdaman.domain.member.deserializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.ikdaman.domain.member.entity.Member;
+
+import java.io.IOException;
+
+public class GenderDeserializer extends JsonDeserializer<Member.Gender> {
+    @Override
+    public Member.Gender deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        String value = p.getValueAsString();
+
+        if (value == null) {
+            // 실제 null인 경우
+            return null;
+        }
+        if (value.trim().isEmpty()) {
+            // 빈 문자열인 경우
+            return Member.Gender.BLANK;
+        }
+        return Member.Gender.valueOf(value.toUpperCase());
+    }
+}

--- a/src/main/java/com/ikdaman/domain/member/entity/Member.java
+++ b/src/main/java/com/ikdaman/domain/member/entity/Member.java
@@ -59,7 +59,7 @@ public class Member extends BaseTime {
 
     // 성별 ENUM
     public enum Gender {
-        FEMALE, MALE
+        FEMALE, MALE, BLANK
     }
 
     // 소셜 로그인 제공자 ENUM

--- a/src/main/java/com/ikdaman/domain/member/model/MemberReq.java
+++ b/src/main/java/com/ikdaman/domain/member/model/MemberReq.java
@@ -1,5 +1,8 @@
 package com.ikdaman.domain.member.model;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.ikdaman.domain.member.deserializer.BirthDateDeserializer;
+import com.ikdaman.domain.member.deserializer.GenderDeserializer;
 import com.ikdaman.domain.member.entity.Member;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
@@ -7,7 +10,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -24,7 +26,9 @@ public class MemberReq {
     @Size(min=2, max=15, message = "닉네임은 최소 2자, 최대 15자만 가능합니다.")
     @Pattern(regexp = "^[a-zA-Z0-9가-힣\\s]+$", message = "닉네임은 한글, 영어, 숫자, 공백만을 포함합니다.")
     private String nickname;
+    @JsonDeserialize(using = GenderDeserializer.class)
     private Member.Gender gender;
+    @JsonDeserialize(using = BirthDateDeserializer.class)
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate birthdate;
 

--- a/src/main/java/com/ikdaman/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/ikdaman/domain/member/service/MemberServiceImpl.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -77,8 +78,12 @@ public class MemberServiceImpl implements MemberService {
         }
 
         member.updateNickname(Optional.ofNullable(memberReq.getNickname()).orElse(member.getNickname()));
-        member.updateBirthdate(Optional.ofNullable(memberReq.getBirthdate()).orElse(member.getBirthdate()));
-        member.updateGender(Optional.ofNullable(memberReq.getGender()).orElse(member.getGender()));
+        // birthdate 필드를 null인 채로 보냈다면 갱신하지 않음, 빈 문자열로 보낸다면 null 처리 (빈 문자열은 Deserializer에서 LocalDate.MIN 처리 됨)
+        LocalDate birthDate = Optional.ofNullable(memberReq.getBirthdate()).orElse(member.getBirthdate());
+        member.updateBirthdate((birthDate != LocalDate.MIN) ? birthDate : null);
+        // gender 필드를 null인 채로 보냈다면 갱신 하지 않음, 빈 문자열로 보낸다면 null 처리
+        Member.Gender gender = Optional.ofNullable(memberReq.getGender()).orElse(member.getGender());
+        member.updateGender((gender != Member.Gender.BLANK) ? gender : null);
 
         memberRepository.save(member);
 


### PR DESCRIPTION
### 무엇을 위한 PR인가요?(: 뒤 설명추가)

- [x] 신규 기능 추가 : 내 정보 수정 시 null과 blank를 구분할 수 있도록 수정
- [ ] 버그 수정 :
- [ ] 리펙토링 :
- [ ] 문서 업데이트 :
- [ ] 기타 : 

### 변경사항 및 이유

- 기존 로직의 경우, Request 필드 값을 빈 문자열로 보내는 경우, 역직렬화 과정에서 null처리가 되었음.
이를 방지하기 위해 Custom Deserializer를 활용, 특정 값을 부여하여 blank와 null값을 구분함
